### PR TITLE
Overhaul asset library, add DPI property to images

### DIFF
--- a/src/client/components/GMArea.tsx
+++ b/src/client/components/GMArea.tsx
@@ -1,5 +1,12 @@
+import clsx from "clsx";
 import React from "react";
 
-export function GMArea(props: { children: React.ReactNode }) {
-  return <div className="gm-area">{props.children}</div>;
+export function GMArea({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return <div className={clsx("gm-area", className)}>{children}</div>;
 }

--- a/src/client/components/assetLibrary/AssetLibrary.tsx
+++ b/src/client/components/assetLibrary/AssetLibrary.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { assetRemove } from "../../../shared/actions";
+import { assetImageUpdate, assetRemove } from "../../../shared/actions";
 import {
   entries,
   RRAsset,
@@ -16,6 +16,29 @@ import { BlurHashImage } from "../blurHash/BlurHashImage";
 import { GMArea } from "../GMArea";
 import { Button } from "../ui/Button";
 import { Select } from "../ui/Select";
+import { SmartTextInput } from "../ui/TextInput";
+import { matchSorter } from "match-sorter";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faCog,
+  faDownload,
+  faTrashAlt,
+} from "@fortawesome/free-solid-svg-icons";
+import { useDrag } from "react-dnd";
+import clsx from "clsx";
+import { useAskForDPI } from "../../util";
+
+const assetTypeOptions = [
+  { value: "image", label: "Images" },
+  { value: "song", label: "Songs" },
+  { value: "other", label: "Other" },
+] as const;
+
+const imageTypeOptions = [
+  { value: "map", label: "Map Objects" },
+  { value: "token", label: "Tokens" },
+  { value: "unknown", label: "Other" },
+] as const;
 
 export const AssetLibrary = React.memo(function AssetLibrary() {
   const assets = useServerState((state) => state.assets);
@@ -24,15 +47,17 @@ export const AssetLibrary = React.memo(function AssetLibrary() {
 
   const [assetTypeFilter, setAssetTypeFilter] = useState<
     RRAsset["type"] | "all"
-  >("all");
+  >("image");
 
   const [imageTypeFilter, setImageTypeFilter] = useState<
     RRAssetImage["originalFunction"] | "all"
-  >("all");
+  >("map");
 
   const [playerFilter, setPlayerFilter] = useState<RRPlayerID | "all">(
     myself.id
   );
+
+  const [nameFilter, setNameFilter] = useState("");
 
   useEffect(() => {
     if (!myself.isGM) {
@@ -68,65 +93,32 @@ export const AssetLibrary = React.memo(function AssetLibrary() {
     });
   }, [players]);
 
+  const filteredAssets = matchSorter(
+    entries(assets).filter(
+      (asset) =>
+        !isTabletopAudioAsset.safeParse(asset).success &&
+        (assetTypeFilter === "all" || asset.type === assetTypeFilter) &&
+        (imageTypeFilter === "all" ||
+          asset.type !== "image" ||
+          asset.originalFunction === imageTypeFilter) &&
+        (playerFilter === "all" || asset.playerId === playerFilter)
+    ),
+    nameFilter,
+    {
+      keys: ["name", "description", "tags.*"],
+      threshold: matchSorter.rankings.ACRONYM,
+    }
+  );
+
+  const dense = imageTypeFilter === "map" && assetTypeFilter === "image";
+
   return (
     <>
       <h1>Asset Library</h1>
-      <label>
-        Type:{" "}
-        <Select
-          value={assetTypeFilter}
-          onChange={(value) => setAssetTypeFilter(value)}
-          options={[
-            {
-              value: "all",
-              label: "all",
-            },
-            {
-              value: "image",
-              label: "images",
-            },
-            {
-              value: "song",
-              label: "music",
-            },
-            {
-              value: "other",
-              label: "other",
-            },
-          ]}
-        />
-      </label>
-      {assetTypeFilter === "image" && (
-        <label>
-          Image Type:{" "}
-          <Select
-            value={imageTypeFilter}
-            onChange={(value) => setImageTypeFilter(value)}
-            options={[
-              {
-                value: "all",
-                label: "all",
-              },
-              {
-                value: "token",
-                label: "token",
-              },
-              {
-                value: "map",
-                label: "map",
-              },
-              {
-                value: "unknown",
-                label: "other",
-              },
-            ]}
-          />
-        </label>
-      )}
       {myself.isGM && (
-        <GMArea>
+        <GMArea className="mb-2">
           <label>
-            Player:{" "}
+            Filter by player:{" "}
             <Select
               value={playerFilter}
               onChange={(value) => setPlayerFilter(value)}
@@ -144,81 +136,228 @@ export const AssetLibrary = React.memo(function AssetLibrary() {
           </label>
         </GMArea>
       )}
-      <ul>
-        {entries(assets)
-          .filter(
-            (asset) =>
-              !isTabletopAudioAsset.safeParse(asset).success &&
-              (assetTypeFilter === "all" || asset.type === assetTypeFilter) &&
-              (imageTypeFilter === "all" ||
-                asset.type !== "image" ||
-                asset.originalFunction === imageTypeFilter) &&
-              (playerFilter === "all" || asset.playerId === playerFilter)
-          )
-          .map((asset) => (
-            <Asset key={asset.id} asset={asset} playerNames={playerNames} />
-          ))}
+      <Tabs
+        value={assetTypeFilter}
+        onChange={(value) => setAssetTypeFilter(value)}
+        tabs={assetTypeOptions}
+      />
+      {assetTypeFilter === "image" && (
+        <Tabs
+          className="text-sm"
+          value={imageTypeFilter}
+          onChange={(value) => setImageTypeFilter(value)}
+          tabs={imageTypeOptions}
+        />
+      )}
+      <div className="-mx-3 mt-[1px]">
+        <SmartTextInput
+          className="px-3 py-1 bg-rr-100 placeholder-rr-500"
+          value={nameFilter}
+          onChange={setNameFilter}
+          placeholder="filter assets"
+          type="search"
+        />
+      </div>
+
+      <ul
+        className={clsx("-mx-3", {
+          "grid grid-cols-3": dense,
+        })}
+      >
+        {filteredAssets.map((asset) => (
+          <Asset
+            key={asset.id}
+            asset={asset}
+            playerNames={playerNames}
+            dense={dense}
+          />
+        ))}
+        {filteredAssets.length === 0 && (
+          <li className="p-1 text-center italic">
+            no assets found matching your filters
+          </li>
+        )}
       </ul>
     </>
   );
 });
 
+function Tabs<V extends string>({
+  tabs,
+  value,
+  onChange,
+  className,
+}: {
+  tabs: ReadonlyArray<{ label: string; value: V }>;
+  value: V;
+  onChange: (value: V) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={clsx(
+        "-mx-3 px-3 flex bg-rr-600 border-b-2 border-rr-500",
+        className
+      )}
+    >
+      {tabs.map((tab) => (
+        <Button
+          key={tab.value}
+          unstyled
+          className={clsx(
+            "px-4 py-1 hover:bg-rr-500 border-r-2 border-rr-500 last:border-r-0",
+            {
+              "font-bold": tab.value === value,
+            }
+          )}
+          onClick={() => onChange(tab.value)}
+        >
+          {tab.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
 function Asset({
   asset,
   playerNames,
+  dense,
 }: {
   asset: RRAsset;
   playerNames: Map<RRPlayerID, string>;
+  dense: boolean;
 }) {
   const dispatch = useServerDispatch();
   const confirm = useConfirm();
-  const download = () => window.open(assetUrl(asset), "_blank")?.focus();
+  const onDownload = () => window.open(assetUrl(asset), "_blank")?.focus();
+  const askForDPI = useAskForDPI();
+  const onOpenSettings = async () => {
+    if (asset.type !== "image") {
+      return;
+    }
+    const dpi = await askForDPI(asset.dpi);
+    if (dpi !== null) {
+      dispatch(assetImageUpdate({ id: asset.id, changes: { dpi } }));
+    }
+  };
 
   return (
-    <li>
-      {asset.type === "image" &&
-        (() => {
-          const MAX_HEIGHT = 100;
-          const height = Math.min(asset.height, MAX_HEIGHT);
-
-          return (
-            <BlurHashImage
-              image={asset}
-              width={asset.width * (height / asset.height)}
-              height={height}
-              loading="lazy"
-              style={{
-                width: "auto",
-                height: "auto",
-                maxHeight: MAX_HEIGHT,
-                cursor: "pointer",
-              }}
-              onClick={download}
-            />
-          );
-        })()}
-      <strong>
-        <span className="ascii-art">{asset.type}</span> {asset.name}
-      </strong>
-      <br />
-      Player: {asset.playerId ? playerNames.get(asset.playerId) : <em>none</em>}
-      <br />
-      <Button onClick={download}>download</Button>
-      <Button
-        className="red"
-        onClick={async () => {
-          if (
-            await confirm(
-              "Are you sure you want to delete this asset forever? Note that it might still be in use somewhere. Also note that the asset will currently not be deleted from the server."
-            )
-          ) {
-            dispatch(assetRemove(asset.id));
-          }
-        }}
+    <li className="flex flex-col px-3 py-2 border-b-2 border-rr-500">
+      <span className="flex">
+        <span
+          className={clsx("flex-1 font-bold line-clamp-2", {
+            "text-xs mb-1 line-clamp-2 break-words": dense,
+            truncate: !dense,
+          })}
+          title={asset.name}
+        >
+          {asset.name}
+        </span>
+        {!dense && <span className="ml-2 font-mono">{asset.type}</span>}
+      </span>
+      <span
+        className={clsx("flex", {
+          "justify-end": !dense,
+          "justify-center": dense,
+        })}
       >
-        delete
-      </Button>
-      <hr />
+        {asset.type === "image" && <DraggableImagePreview asset={asset} />}
+      </span>
+      <span className="flex-1" />
+      <span
+        className={clsx("flex items-end text-xs", {
+          " -mt-6": dense,
+        })}
+      >
+        <span className="flex-1">
+          {!dense && (
+            <>
+              ~{" "}
+              {(asset.playerId && playerNames.get(asset.playerId)) ?? (
+                <em>unknown</em>
+              )}
+            </>
+          )}
+          {asset.type === "image" && asset.dpi !== null && (
+            <span>
+              {" "}
+              {Math.round(asset.width / asset.dpi)}×
+              {Math.round(asset.height / asset.dpi)}
+            </span>
+          )}
+        </span>
+
+        {asset.type === "image" && (
+          <Button
+            unstyled
+            className="ml-2"
+            onClick={onOpenSettings}
+            title="download"
+          >
+            <FontAwesomeIcon icon={faCog} />
+          </Button>
+        )}
+        <Button unstyled className="ml-2" onClick={onDownload} title="download">
+          <FontAwesomeIcon icon={faDownload} />
+        </Button>
+        <Button
+          unstyled
+          className="ml-2 text-red-500"
+          title="delete"
+          onClick={async () => {
+            if (
+              await confirm(
+                "Are you sure you want to delete this asset forever? It might still be in use somewhere and might break when it is deleted. Note: assets will currently never be deleted from the server."
+              )
+            ) {
+              dispatch(assetRemove(asset.id));
+            }
+          }}
+        >
+          <FontAwesomeIcon icon={faTrashAlt} />
+        </Button>
+      </span>
+      {!dense && <span>{asset.tags.join(", ")}</span>}
     </li>
+  );
+}
+
+function DraggableImagePreview({ asset }: { asset: RRAssetImage }) {
+  const canDrag = asset.originalFunction === "map";
+
+  const [_, dragRef] = useDrag(
+    () => ({
+      type: "asset/image",
+      item: { imageAsset: asset },
+      options: {
+        dropEffect: "copy",
+      },
+      canDrag,
+    }),
+    [canDrag, asset]
+  );
+
+  const MAX_HEIGHT = 100;
+  const height = Math.min(asset.height, MAX_HEIGHT);
+
+  return (
+    <BlurHashImage
+      // Make sure to not set the ref when the image should not be draggable,
+      // since otherwise the draggable attribute will automatically be set to
+      // true, regardless of how we set it below.
+      ref={canDrag ? dragRef : undefined}
+      image={asset}
+      width={asset.width * (height / asset.height)}
+      height={height}
+      loading="lazy"
+      className={clsx("w-auto h-auto my-1", {
+        "cursor-move": canDrag,
+      })}
+      draggable={canDrag}
+      style={{
+        maxHeight: MAX_HEIGHT,
+      }}
+    />
   );
 }

--- a/src/client/components/characters/CharacterManager.tsx
+++ b/src/client/components/characters/CharacterManager.tsx
@@ -49,6 +49,7 @@ async function makeNewCharacter(
     blurHash: image.blurHash,
     width: image.width,
     height: image.height,
+    dpi: null,
 
     playerId: myId,
   });

--- a/src/client/components/map/useMapToolHandler.tsx
+++ b/src/client/components/map/useMapToolHandler.tsx
@@ -15,10 +15,7 @@ import {
   RRPoint,
 } from "../../../shared/state";
 import { useServerDispatch } from "../../state";
-import {
-  DEFAULT_BACKGROUND_IMAGE_HEIGHT,
-  GRID_SIZE,
-} from "../../../shared/constants";
+import { GRID_SIZE } from "../../../shared/constants";
 import { assertNever, rrid, withDo } from "../../../shared/util";
 import { askAndUploadImages } from "../../files";
 import {
@@ -35,6 +32,7 @@ import { RRMapViewRef } from "./Map";
 import { usePrompt } from "../../dialog-boxes";
 import { PRectangle } from "./Primitives";
 import { colorValue } from "./pixi-utils";
+import { mapObjectImageHeightFromAsset, useAskForDPI } from "../../util";
 
 const SERVER_SYNC_THROTTLE_TIME = 100;
 
@@ -114,6 +112,7 @@ export function useMapToolHandler(
   const { send } = useServerMessages();
 
   const prompt = usePrompt();
+  const askForDPI = useAskForDPI();
 
   if (editState.tool === "draw") {
     const create = (p: RRPoint) => ({
@@ -379,6 +378,8 @@ export function useMapToolHandler(
               return;
             }
 
+            const dpi = await askForDPI();
+
             const assetImageAddAction = assetImageAdd({
               name: image.originalFilename,
               description: null,
@@ -397,13 +398,17 @@ export function useMapToolHandler(
               blurHash: image.blurHash,
               width: image.width,
               height: image.height,
+              dpi,
 
               playerId: myself.id,
             });
 
             const mapObjectAddAction = mapObjectAdd(mapId, {
               type: "image",
-              height: DEFAULT_BACKGROUND_IMAGE_HEIGHT,
+              height: mapObjectImageHeightFromAsset({
+                height: image.height,
+                dpi,
+              }),
               imageAssetId: assetImageAddAction.payload.id,
               ...create(p),
             });

--- a/src/client/components/quickReference/QuickReferenceMonster.tsx
+++ b/src/client/components/quickReference/QuickReferenceMonster.tsx
@@ -89,6 +89,7 @@ export const Monster = React.memo(function Monster({
       blurHash: image.blurHash,
       width: image.width,
       height: image.height,
+      dpi: null,
 
       playerId: myself.id,
     });

--- a/src/client/components/ui/Select.tsx
+++ b/src/client/components/ui/Select.tsx
@@ -15,7 +15,7 @@ export function Select<O extends string>({
   onChange,
   ...props
 }: PassedThroughProps & {
-  options: { value: O; label: string }[];
+  options: ReadonlyArray<{ value: O; label: string }>;
   value: O;
   onChange: (option: O) => void;
 }) {

--- a/src/client/util.tsx
+++ b/src/client/util.tsx
@@ -1,12 +1,17 @@
 import React, { ReactNode, useCallback, useMemo } from "react";
 import { characterUpdate } from "../shared/actions";
-import { DEFAULT_SYNC_TO_SERVER_DEBOUNCE_TIME } from "../shared/constants";
+import {
+  DEFAULT_BACKGROUND_IMAGE_HEIGHT,
+  DEFAULT_SYNC_TO_SERVER_DEBOUNCE_TIME,
+  GRID_SIZE,
+} from "../shared/constants";
 import tinycolor from "tinycolor2";
 import { applyToPoint, inverse, Matrix } from "transformation-matrix";
 import { makePoint } from "../shared/point";
 import {
   EntityCollection,
   proficiencyValues,
+  RRAssetImage,
   RRCharacter,
   RRCharacterID,
   RRPoint,
@@ -14,7 +19,7 @@ import {
 } from "../shared/state";
 import { DialogTitle, DialogContent, DialogActions } from "./components/Dialog";
 import { Button } from "./components/ui/Button";
-import { useDialog } from "./dialog-boxes";
+import { useDialog, usePrompt } from "./dialog-boxes";
 import { useServerDispatch } from "./state";
 import { clamp } from "../shared/util";
 
@@ -326,4 +331,31 @@ export function getLogRollName(
     : logNames === "characterName"
     ? characterNames
     : characterNames + " (" + playerName + ")";
+}
+
+export function useAskForDPI() {
+  const prompt = usePrompt();
+  return useCallback(
+    async (initialDPI?: number | null) => {
+      const dpi = parseFloat(
+        (
+          await prompt(
+            "How many pixels per inch/map square? Leave empty if unsure. This only affects the initial size of the image when dragging it onto the map. You can always modify the image size later.",
+            initialDPI?.toString()
+          )
+        )?.trim() ?? "0"
+      );
+      return !isNaN(dpi) && isFinite(dpi) && dpi > 0 ? dpi : null;
+    },
+    [prompt]
+  );
+}
+
+export function mapObjectImageHeightFromAsset({
+  height,
+  dpi,
+}: Pick<RRAssetImage, "height" | "dpi">) {
+  return dpi === null
+    ? DEFAULT_BACKGROUND_IMAGE_HEIGHT
+    : (height * GRID_SIZE) / dpi;
 }

--- a/src/server/migrations/37_image_dpi_and_filename.ts
+++ b/src/server/migrations/37_image_dpi_and_filename.ts
@@ -1,0 +1,23 @@
+import { AbstractMigration } from "../migrations";
+
+export default class extends AbstractMigration {
+  version = 37;
+
+  migrate = (state: any) => {
+    Object.values(
+      state.assets.entities as Record<
+        string,
+        { name: string; type: string; dpi: any; location: any }
+      >
+    ).forEach((asset) => {
+      if (asset.type === "image") {
+        asset.dpi ??= null;
+      }
+      if (asset.location.type === "local") {
+        asset.name = asset.location.originalFilename;
+      }
+    });
+
+    return state;
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,7 +14,7 @@ export const FORCE_COMMIT_FIELD_VALUE_AFTER = 5 * 1000;
 
 export const STORE_SUBSCRIPTION_THROTTLE = 100;
 
-export const LAST_MIGRATION_VERSION = 36;
+export const LAST_MIGRATION_VERSION = 37;
 
 export const SYNC_MY_MOUSE_POSITION = true as boolean;
 

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -126,6 +126,7 @@ const isRRAssetImage = z.strictObject({
   type: z.literal("image"),
   width: z.number().int().min(0),
   height: z.number().int().min(0),
+  dpi: z.number().int().min(0).nullable(),
   blurHash: isBlurHash,
 
   originalFunction: z.enum(["token", "map", "unknown"] as const),
@@ -422,7 +423,7 @@ export const isSyncedState = z.strictObject({
             ...mapObjectDrawingSharedValidators,
             type: z.literal("image"),
             imageAssetId: isRRID<RRAssetID>(),
-            height: z.number().int().min(0),
+            height: z.number().min(0),
           }),
           z.strictObject({
             ...mapObjectDrawingSharedValidators,


### PR DESCRIPTION
The idea with this PR is to make the asset library more powerful: It now allows you to drag and drop uploaded images onto the map, filter images, and configure an image's DPI. Introducing DPI as a concept is useful, because assets such as trees will then automatically have the correct size when dropping them onto the map. Another option would've been to introduce a per-image "default height" instead of DPI. But I felt like DPI is a bit clearer, especially when importing lot's of images (e.g. a large collection of trees and foliage) from the same source at the same time, since they will likely all share the same DPI.