### PR TITLE
make dropdown for token sizes

### DIFF
--- a/src/client/components/characters/CharacterEditor.tsx
+++ b/src/client/components/characters/CharacterEditor.tsx
@@ -60,6 +60,7 @@ import { Collapsible } from "../Collapsible";
 import { Auras } from "./Auras";
 import { FileInput } from "../FileInput";
 import { LimitedUseSkillEditor } from "./LimitedUseItemEditor";
+import { Select } from "../ui/Select";
 
 export interface ConditionWithIcon {
   name: RRCharacterCondition;
@@ -301,20 +302,29 @@ export function CharacterEditor({
         </div>
         <div>
           <label>
-            Size in #squares:{" "}
-            <SmartIntegerInput
-              value={character.scale}
-              min={1}
-              placeholder="scale"
-              onChange={(scale) =>
+            Size:{" "}
+            <Select
+              value={character.scale.toString()}
+              onChange={(scale: string) =>
                 dispatch({
                   actions: [
-                    characterUpdate({ id: character.id, changes: { scale } }),
+                    characterUpdate({
+                      id: character.id,
+                      changes: { scale: parseFloat(scale) },
+                    }),
                   ],
                   optimisticKey: "scale",
                   syncToServerThrottle: DEFAULT_SYNC_TO_SERVER_DEBOUNCE_TIME,
                 })
               }
+              options={[
+                { value: "0.5", label: "tiny" },
+                { value: "0.7", label: "small" },
+                { value: "1", label: "medium" },
+                { value: "2", label: "large" },
+                { value: "3", label: "huge" },
+                { value: "4", label: "gargantuan" },
+              ]}
             />
           </label>
         </div>

--- a/src/client/components/map/MapToken.tsx
+++ b/src/client/components/map/MapToken.tsx
@@ -228,7 +228,12 @@ function MapTokenInner({
 
   const tokenSize = GRID_SIZE * character.scale;
 
-  const { x, y } = lerpedPosition;
+  function getSmallTokenOffset() {
+    return character.scale < 1 ? ((1 - character.scale) / 2) * GRID_SIZE : 0;
+  }
+  let { x, y } = lerpedPosition;
+  x += getSmallTokenOffset();
+  y += getSmallTokenOffset();
 
   const fullTokenRepresentation = (
     position: RRPoint,
@@ -239,8 +244,8 @@ function MapTokenInner({
       ref={ref}
       angle={object.rotation}
       pivot={{ x: tokenSize / 2, y: tokenSize / 2 }}
-      x={position.x + tokenSize / 2}
-      y={position.y + tokenSize / 2}
+      x={position.x + tokenSize / 2 + (isGhost ? getSmallTokenOffset() : 0)}
+      y={position.y + tokenSize / 2 + (isGhost ? getSmallTokenOffset() : 0)}
     >
       {isGhost ? (
         <TokenImageOrPlaceholder

--- a/src/client/components/quickReference/QuickReferenceMonster.tsx
+++ b/src/client/components/quickReference/QuickReferenceMonster.tsx
@@ -57,11 +57,12 @@ export const Monster = React.memo(function Monster({
     // TODO: Why can some monsters have multiple sizes?
     const size = monster.size?.[0];
 
-    return size === undefined ||
-      size === "T" || // technically these would be a quarter of a square only
-      size === "S" ||
-      size === "M"
+    return size === undefined || size === "M"
       ? 1
+      : size === "T"
+      ? 0.5
+      : size === "S"
+      ? 0.7
       : size === "L"
       ? 2
       : size === "H"

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -323,7 +323,7 @@ export const isSyncedState = z.strictObject({
 
       tokenImageAssetId: isRRID<RRAssetID>(),
       tokenBorderColor: isColor,
-      scale: z.number().min(1),
+      scale: z.number().min(0),
 
       auras: z.array(
         z.strictObject({


### PR DESCRIPTION
* fixes #198 
* fixes #194, but tiny and small tokens are centred on the tile, so we still cant have four tiny characters on one spot. Do we want to figure out a way to do this dynamically so tokens are moved into the corners when multiple tiny tokens are present?