### PR TITLE
fix: Only update concentration when old and new initiative entry exist

### DIFF
--- a/src/client/components/characters/CharacterManager.tsx
+++ b/src/client/components/characters/CharacterManager.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../../shared/actions";
 import {
   entries,
+  makeCharacter,
   RRCharacter,
   RRCharacterID,
   RRFileImage,
@@ -52,68 +53,13 @@ async function makeNewCharacter(
 
     playerId: myId,
   });
-
   const addAction = characterAdd({
-    auras: [],
-    conditions: [],
-    hp: 0,
-    maxHP: 0,
-    temporaryHP: 0,
-    maxHPAdjustment: 0,
-    ac: null,
-    spellSaveDC: null,
-    scale: 1,
-    visibility: "everyone",
-    limitedUseSkills: [],
-    attributes: {
-      initiative: null,
-      proficiency: null,
-    },
-    stats: {
-      STR: null,
-      DEX: null,
-      CON: null,
-      INT: null,
-      WIS: null,
-      CHA: null,
-    },
-    savingThrows: {
-      STR: null,
-      DEX: null,
-      CON: null,
-      INT: null,
-      WIS: null,
-      CHA: null,
-    },
-    skills: {
-      Athletics: null,
-      Acrobatics: null,
-      "Sleight of Hand": null,
-      Stealth: null,
-      Arcana: null,
-      History: null,
-      Investigation: null,
-      Nature: null,
-      Religion: null,
-      "Animal Handling": null,
-      Insight: null,
-      Medicine: null,
-      Perception: null,
-      Survival: null,
-      Deception: null,
-      Intimidation: null,
-      Performance: null,
-      Persuasion: null,
-    },
-    name: await randomName(),
-    tokenImageAssetId: assetImageAddAction.payload.id,
-    tokenBorderColor: randomColor(),
-    localToMap: null,
+    ...makeCharacter(
+      await randomName(),
+      assetImageAddAction.payload.id,
+      randomColor()
+    ),
     isTemplate,
-    diceTemplateCategories: [],
-    notes: "",
-    spells: [],
-    currentlyConcentratingOn: null,
   });
 
   return {

--- a/src/shared/reducer.test.ts
+++ b/src/shared/reducer.test.ts
@@ -1,0 +1,108 @@
+import { initiativeTrackerSetCurrentEntry } from "./actions";
+import { reducer } from "./reducer";
+import {
+  initialSyncedState,
+  makeCharacter,
+  RRAsset,
+  RRCharacter,
+  RRInitiativeTrackerEntry,
+  RRInitiativeTrackerEntryID,
+  SyncedState,
+} from "./state";
+import { rrid } from "./util";
+
+describe("withCharacterConcentrationReducer", () => {
+  let state: SyncedState;
+  const characterId = rrid<RRCharacter>();
+  const lairActionId = rrid<RRInitiativeTrackerEntry>();
+  const characterEntryId = rrid<RRInitiativeTrackerEntry>();
+
+  function nextTurn(
+    id: RRInitiativeTrackerEntryID | null,
+    expectedRoundsLeft: number | null
+  ) {
+    state = reducer(state, initiativeTrackerSetCurrentEntry(id));
+    expect(
+      state.characters.entities[characterId]!.currentlyConcentratingOn
+    ).toEqual(
+      expectedRoundsLeft === null
+        ? null
+        : {
+            name: "Light",
+            roundsLeft: expectedRoundsLeft,
+          }
+    );
+  }
+
+  beforeEach(() => {
+    state = {
+      ...initialSyncedState,
+      initiativeTracker: {
+        currentEntryId: null,
+        visible: true,
+        entries: {
+          entities: {
+            [lairActionId]: {
+              id: lairActionId,
+              type: "lairAction",
+              description: "",
+              initiative: 20,
+            },
+            [characterEntryId]: {
+              id: characterEntryId,
+              type: "character",
+              characterIds: [characterId],
+              initiative: 15,
+            },
+          },
+          ids: [lairActionId, characterEntryId],
+        },
+      },
+      characters: {
+        entities: {
+          [characterId]: {
+            id: characterId,
+            ...makeCharacter("", rrid<RRAsset>(), ""),
+            currentlyConcentratingOn: {
+              name: "Light",
+              roundsLeft: 3,
+            },
+          },
+        },
+        ids: [characterId],
+      },
+    };
+  });
+
+  it("works correctly", () => {
+    nextTurn(lairActionId, 3);
+    nextTurn(characterEntryId, 2);
+    nextTurn(lairActionId, 2);
+    nextTurn(characterEntryId, 1);
+    nextTurn(lairActionId, 1);
+    nextTurn(characterEntryId, 0);
+    nextTurn(lairActionId, null);
+    nextTurn(characterEntryId, null);
+    nextTurn(lairActionId, null);
+  });
+  it("does not decrement roundsLeft when starting initiative", () => {
+    nextTurn(characterEntryId, 3);
+    nextTurn(lairActionId, 3);
+    nextTurn(characterEntryId, 2);
+  });
+  it("does not decrement roundsLeft when starting initiative from an invalid currentEntryId", () => {
+    state.initiativeTracker.currentEntryId = rrid<RRInitiativeTrackerEntry>();
+    nextTurn(characterEntryId, 3);
+    nextTurn(lairActionId, 3);
+    nextTurn(characterEntryId, 2);
+  });
+  it("does not decrement roundsLeft when ending initiative", () => {
+    nextTurn(characterEntryId, 3);
+    nextTurn(null, 3);
+  });
+  it("does not decrement roundsLeft when going to the same character", () => {
+    nextTurn(characterEntryId, 3);
+    nextTurn(characterEntryId, 3);
+    nextTurn(characterEntryId, 3);
+  });
+});

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -580,3 +580,73 @@ export interface SyncedStateAction<
 }
 
 export type SyncedStateDispatch = Dispatch<SyncedStateAction>;
+
+export function makeCharacter(
+  name: string,
+  tokenImageAssetId: RRAssetID,
+  tokenBorderColor: RRColor
+): Omit<RRCharacter, "id"> {
+  return {
+    name,
+    tokenImageAssetId,
+    tokenBorderColor,
+
+    auras: [],
+    conditions: [],
+    hp: 0,
+    maxHP: 0,
+    temporaryHP: 0,
+    maxHPAdjustment: 0,
+    ac: null,
+    spellSaveDC: null,
+    scale: 1,
+    visibility: "everyone",
+    limitedUseSkills: [],
+    attributes: {
+      initiative: null,
+      proficiency: null,
+    },
+    stats: {
+      STR: null,
+      DEX: null,
+      CON: null,
+      INT: null,
+      WIS: null,
+      CHA: null,
+    },
+    savingThrows: {
+      STR: null,
+      DEX: null,
+      CON: null,
+      INT: null,
+      WIS: null,
+      CHA: null,
+    },
+    skills: {
+      Athletics: null,
+      Acrobatics: null,
+      "Sleight of Hand": null,
+      Stealth: null,
+      Arcana: null,
+      History: null,
+      Investigation: null,
+      Nature: null,
+      Religion: null,
+      "Animal Handling": null,
+      Insight: null,
+      Medicine: null,
+      Perception: null,
+      Survival: null,
+      Deception: null,
+      Intimidation: null,
+      Performance: null,
+      Persuasion: null,
+    },
+    localToMap: null,
+    isTemplate: false,
+    diceTemplateCategories: [],
+    notes: "",
+    spells: [],
+    currentlyConcentratingOn: null,
+  };
+}


### PR DESCRIPTION
@corinnaj I wrote some tests for the new behavior, and found some instances in where it was not behaving exactly as I would have expected:

- If the same initiative entry is selected as is already active, then I think we should not update concentration spells (this might happen, e.g., if the DM presses the button to jump within the initiative to the same character that is already active).
- If a character (for whatever reason) already has a concentration spell active, and initiative is freshly started (= currentEntryId was null), I also don't think we should update concentration spells, just to be on the safe side.


For these new checks to work, I had to merge both reducers you added into one higher order reducer.
Please take a look and tell me what you think!